### PR TITLE
Align engine name with configuration-aws-database

### DIFF
--- a/apis/postgresql/composition.yaml
+++ b/apis/postgresql/composition.yaml
@@ -3,7 +3,7 @@ kind: Composition
 metadata:
   name: xpostgresqlinstances.azure.platform.upbound.io
   labels:
-    dbengine: postgresql
+    dbengine: postgres
     provider: azure
 spec:
   writeConnectionSecretsToNamespace: upbound-system

--- a/examples/postgres-claim.yaml
+++ b/examples/postgres-claim.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   compositionSelector:
     matchLabels:
-      dbengine: postgresql
+      dbengine: postgres
   parameters:
     region: westus
     storageGB: 5 #Minimum value is 5


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* AWS RDS api takes `postgres`(not `postgresql`) as the engine name
* Aligning Azure dbengine will simplify higher level abstraction management, e.g. we can simplify composition and remove transform in https://github.com/upbound/configuration-dbaas/commit/17be04b4d582d9497e4d7a651ee57ff0e4fe0467#diff-404445aa8a765071facff2b2e3af737de3a17dbb031723c8e775a37b3ae8ec9eR52-R56


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

uptest below
