### PR TITLE
Avoid explicit pin of the family provider azure

### DIFF
--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -17,9 +17,6 @@ spec:
   crossplane:
     version: ">=v1.14.1-0"
   dependsOn:
-    - provider: xpkg.upbound.io/upbound/provider-family-azure
-      # renovate: datasource=github-releases depName=upbound/provider-azure
-      version: "v0.42.1"
     - provider: xpkg.upbound.io/upbound/provider-azure-dbformariadb
       # renovate: datasource=github-releases depName=upbound/provider-azure
       version: "v0.42.1"


### PR DESCRIPTION
### Description of your changes

* This is to avoid dependency conflict situation in the higher level Configurations like platform-ref-azure

* Before the change currently it ends up in degraded state

```
k get configurations
NAME                                      INSTALLED   HEALTHY   PACKAGE                                                          AGE
platform-ref-azure                        True        True      platform-ref-azure-v0.5.0-rc.0.126.g48f317c.gz                   31m
upbound-configuration-app                 True        True      xpkg.upbound.io/upbound/configuration-app:v0.4.0                 31m
upbound-configuration-azure-aks           True        True      xpkg.upbound.io/upbound/configuration-azure-aks:v0.6.0           31m
upbound-configuration-azure-database      True        Unknown   xpkg.upbound.io/upbound/configuration-azure-database:v0.10.0     31m
upbound-configuration-azure-network       True        True      xpkg.upbound.io/upbound/configuration-azure-network:v0.7.0       31m
upbound-configuration-gitops-flux         True        True      xpkg.upbound.io/upbound/configuration-gitops-flux:v0.4.0         30m
upbound-configuration-observability-oss   True        True      xpkg.upbound.io/upbound/configuration-observability-oss:v0.4.0   30m
```

```
k describe configurationrevisions.pkg.crossplane.io upbound-configuration-azure-database-820ed7390759
...
Status:
  Conditions:
    Last Transition Time:  2024-04-04T10:54:18Z
    Message:               cannot resolve package dependencies: incompatible dependencies: [xpkg.upbound.io/upbound/provider-family-azure]
    Reason:                UnknownPackageRevisionHealth
    Status:                Unknown
    Type:                  Healthy
...
  Warning  ResolveDependencies  25s (x32 over 30m)  packages/configurationrevision.pkg.crossplane.io  cannot resolve package dependencies: incompatible dependencies: [xpkg.upbound.io/upbound/provider-family-azure]
```

Some other configurations pulled in the higher version of the family provider with its implicit pulling mechanism of latest

```
 k get providers
NAME                                      INSTALLED   HEALTHY   PACKAGE                                                           AGE
crossplane-contrib-provider-helm          True        True      xpkg.upbound.io/crossplane-contrib/provider-helm:v0.16.0          31m
crossplane-contrib-provider-kubernetes    True        True      xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.11.4    31m
grafana-provider-grafana                  True        True      xpkg.upbound.io/grafana/provider-grafana:v0.8.0                   31m
upbound-provider-azure-containerservice   True        True      xpkg.upbound.io/upbound/provider-azure-containerservice:v0.42.1   32m
upbound-provider-azure-dbformariadb       True        True      xpkg.upbound.io/upbound/provider-azure-dbformariadb:v0.42.1       31m
upbound-provider-azure-dbforpostgresql    True        True      xpkg.upbound.io/upbound/provider-azure-dbforpostgresql:v0.42.1    31m
upbound-provider-azure-network            True        True      xpkg.upbound.io/upbound/provider-azure-network:v0.42.1            31m
upbound-provider-family-azure             True        True      xpkg.upbound.io/upbound/provider-family-azure:v1.0.0              31m
```

and it broke the dependency resolution.

Removing explicit pin should mitigate the issue.

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->



<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
